### PR TITLE
Allow to configure reCAPTCHA verify endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sends form submission to Slack.
 ## Requirements
 
 - Go
-- reCAPTCHA v3
+- Secret key for a reCAPTCHA-compatible service
 - Slack Webhook URL
 
 ## Installation
@@ -24,6 +24,9 @@ export PORT=8080
 # TLS certificate and private key (optional; if not specified, form-to-slack is served over HTTP)
 export TLS_CERT=/path/to/tls/cert
 export TLS_KEY=/path/to/tls/key
+
+# reCAPTCHA verify endpoint (optional; if not specified, it defaults to reCAPTCHA)
+export RECAPTCHA_URL=https://www.google.com/recaptcha/api/siteverify
 
 # reCAPTCHA secret key (required)
 export RECAPTCHA_SECRET=

--- a/application/server/engine.go
+++ b/application/server/engine.go
@@ -19,6 +19,7 @@ type engine struct {
 	CertFile        string
 	KeyFile         string
 	AllowedOrigins  string
+	ReCaptchaURL    string
 	ReCaptchaSecret string
 	SlackService    service.SlackService
 }
@@ -32,6 +33,7 @@ func NewEngine(
 	certFile string,
 	keyFile string,
 	allowedOrigins string,
+	reCaptchaURL string,
 	reCaptchaSecret string,
 	slackService service.SlackService,
 ) Engine {
@@ -40,6 +42,7 @@ func NewEngine(
 		CertFile:        certFile,
 		KeyFile:         keyFile,
 		AllowedOrigins:  allowedOrigins,
+		ReCaptchaURL:    reCaptchaURL,
 		ReCaptchaSecret: reCaptchaSecret,
 		SlackService:    slackService,
 	}

--- a/application/server/recaptcha.go
+++ b/application/server/recaptcha.go
@@ -19,17 +19,13 @@ type reCaptchaResponse struct {
 	ErrorCodes  []string  `json:"error-codes"`
 }
 
-const (
-	reCaptchaVerifyEndpoint = "https://www.google.com/recaptcha/api/siteverify"
-)
-
 func (e *engine) verifyReCaptcha(ctx context.Context, response string) (bool, error) {
 	body := url.Values{
 		"secret":   {e.ReCaptchaSecret},
 		"response": {response},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reCaptchaVerifyEndpoint, strings.NewReader(body.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.ReCaptchaURL, strings.NewReader(body.Encode()))
 	if err != nil {
 		return false, fmt.Errorf("failed to construct a request: %w", err)
 	}

--- a/infrastructure/config/env.go
+++ b/infrastructure/config/env.go
@@ -6,11 +6,16 @@ import (
 	"strings"
 )
 
+const (
+	defaultReCaptchaVerifyEndpoint = "https://www.google.com/recaptcha/api/siteverify"
+)
+
 type Environment struct {
 	AllowedOrigins  string
 	Port            string
 	TLSCert         string
 	TLSKey          string
+	ReCaptchaURL    string
 	ReCaptchaSecret string
 	SlackWebhookURL string
 }
@@ -23,6 +28,7 @@ func Get() (Environment, error) {
 		"ALLOWED_ORIGINS": &env.AllowedOrigins,
 		"TLS_CERT":        &env.TLSCert,
 		"TLS_KEY":         &env.TLSKey,
+		"RECAPTCHA_URL":   &env.ReCaptchaURL,
 	} {
 		*v = os.Getenv(k)
 	}
@@ -41,6 +47,10 @@ func Get() (Environment, error) {
 
 	if len(missing) > 0 {
 		return env, errors.New("missing env(s): " + strings.Join(missing, ", "))
+	}
+
+	if env.ReCaptchaURL == "" {
+		env.ReCaptchaURL = defaultReCaptchaVerifyEndpoint
 	}
 
 	return env, nil

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	slackNotifier := slack.NewSlackNotifier(env.SlackWebhookURL)
 	slackService := service.NewSlackService(slackNotifier)
-	engine := server.NewEngine(env.Port, env.TLSCert, env.TLSKey, env.AllowedOrigins, env.ReCaptchaSecret, slackService)
+	engine := server.NewEngine(env.Port, env.TLSCert, env.TLSKey, env.AllowedOrigins, env.ReCaptchaURL, env.ReCaptchaSecret, slackService)
 	err = engine.Start(ctx)
 	if err != nil {
 		logrus.Fatalf("Failed to start web server: %v", err)


### PR DESCRIPTION
This configuration is useful for services like Cloudflare Turnstile.